### PR TITLE
Fix circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,17 @@ jobs:
           name: list available images
           command: docker images fundocker/nextcloud
 
+      # Login to DockerHub to Publish new images
+      #
+      # Nota bene: you'll need to define the following secrets environment vars
+      # in CircleCI interface:
+      #
+      #   - DOCKER_USER
+      #   - DOCKER_PASS
+      - run:
+          name: Login to DockerHub
+          command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+
       - run:
           name: tag images
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run:
           name: Build Nextcloud image
           command: |
-            source ./circleci/release.sh
+            source ./.circleci/release.sh
             docker build -t fundocker/nextcloud:${CIRCLE_SHA1} \
               --build-arg NEXTCLOUD_VERSION=${NEXTCLOUD_VERSION} \
               .
@@ -29,7 +29,7 @@ jobs:
       - run:
           name: Build Nextcloud image
           command: |
-            source ./circleci/release.sh
+            source ./.circleci/release.sh
             docker build -t fundocker/nextcloud:${CIRCLE_SHA1} \
               --build-arg NEXTCLOUD_VERSION=${NEXTCLOUD_VERSION} \
               .
@@ -41,7 +41,7 @@ jobs:
       - run:
           name: tag images
           command: |
-            source ./circleci/release.sh
+            source ./.circleci/release.sh
             docker tag fundocker/nextcloud:${CIRCLE_SHA1} fundocker/nextcloud:latest
             docker tag fundocker/nextcloud:${CIRCLE_SHA1} fundocker/nextcloud:${NEXTCLOUD_VERSION}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ USER root
 # docker user (see entrypoint).
 RUN chmod g=u /etc/passwd
 
-RUN mv /usr/src/nextcloud /app && \
-    chown -R ${USER_ID}:root /app
-COPY --chown=${USER_ID}:root config/nextcloud/* /app/config/
+RUN mv /usr/src/nextcloud /app
+COPY config/nextcloud/* /app/config/
+RUN chown -R ${USER_ID}:root /app
 
 # Use the default production configuration
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
@@ -20,7 +20,8 @@ COPY config/php/* ${PHP_INI_DIR}/conf.d/
 COPY config/php-fpm/* /usr/local/etc/php-fpm.d/
 
 COPY bin/entrypoint.sh /usr/local/bin/entrypoint.sh
-COPY --chown=${USER_ID}:root bin/install.sh /usr/local/bin/install.sh
+COPY bin/install.sh /usr/local/bin/install.sh
+RUN chown ${USER_ID}:root /usr/local/bin/install.sh
 
 ENV NEXTCLOUD_PHP_FPM_PM=dynamic \
     NEXTCLOUD_PHP_FPM_PM_MAX_CHILDREN=5 \


### PR DESCRIPTION
### Purpose

The path used to access circleci was wrong, the leading dot was missing.
Also to use the `--chown` option on `COPY` step, the user id must exists on the system and it's not the case on Circleci. To avoid failure the `chown` is made in a new `RUN` step

### Proposal

- [x] fix circleci path
- [x] run `chown` in a dedicated `RUN` step
- [x] add missing step to connect to docker hub

