### PR TITLE
🐛(nextcloud) remove enable user_saml instruction in install.sh

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -37,8 +37,6 @@ if [ -n "${NEXTCLOUD_ADMIN_USER+x}" ] && [ -n "${NEXTCLOUD_ADMIN_PASSWORD+x}" ];
         exit 1
     fi
 
-    php /app/occ app:enable user_saml
-
     touch /tmp/nextcloud/installed
 
 else


### PR DESCRIPTION
### Purpose

In the install.sh script we are trying to enable the app user_saml but
this app is not installed in this image. The install.sh script will fail
on every installation.

### Proposal

- [x] remove `app:enable` command in `install.sh` script