### PR TITLE
add build job as required to launch hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - run:
           name: publish images
           command: |
-            source ./circleci/release.sh
+            source ./.circleci/release.sh
             docker push fundocker/nextcloud:latest
             docker push fundocker/nextcloud:${NEXTCLOUD_VERSION}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,8 @@ workflows:
             tags:
               only: /.*/
       - hub:
+          requires:
+            - build
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
### Purpose

The hub job should be launched only if the build is in success.
Also in the hub step the path to `.circleci` directory was wrong

### Proposal

- [x] fix path to `.circleci` directory in hub job
- [x] add a requirement to hub job. The build job must be in success in order to run the hub job